### PR TITLE
build: 配置npm包的有效文件

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/type/main.d.ts",
   "publisher": "magicalprogrammer@qq.com",
   "scripts": {
-    "build": "vue-cli-service build --target lib --name screenShotPlugin src/main.ts",
+    "build": "vue-cli-service build --target lib --name screenShotPlugin src/main.ts && rm ./dist/demo.html",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "commit": "git-cz"
   },
@@ -66,5 +66,6 @@
   },
   "dependencies": {
     "html2canvas": "^1.0.0-rc.7"
-  }
+  },
+  "files": ["/dist"]
 }


### PR DESCRIPTION
下载下来的 `npm` 包发现有些多余文件, 加了个配置把包的多余文件过滤掉
![image](https://user-images.githubusercontent.com/59595216/216545134-4d262493-6cbf-4067-9adb-7c3373779026.png)
![image](https://user-images.githubusercontent.com/59595216/216545181-9ae2c1e0-16bf-47bf-bb4e-17b687f16bb5.png)
