### PR TITLE
fix: 修复dom销毁异常时, tool工具栏会出现渲染异常的bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "sass-loader": "^8.0.2",
     "ts-jest": "^29.0.5",
     "tsc-alias": "^1.8.7",
+    "tslib": "^2.6.2",
     "typescript": "~5.0.4",
     "yargs": "^17.7.1"
   },

--- a/src/lib/main-entrance/CreateDom.ts
+++ b/src/lib/main-entrance/CreateDom.ts
@@ -304,12 +304,23 @@ export default class CreateDom {
 
   // 将截图相关dom渲染至body
   private setDomToBody() {
+    this.clearBody();
     document.body.appendChild(this.screenShotController);
     document.body.appendChild(this.toolController);
     document.body.appendChild(this.optionIcoController);
     document.body.appendChild(this.optionController);
     document.body.appendChild(this.cutBoxSizeContainer);
     document.body.appendChild(this.textInputController);
+  }
+
+  // 清除截图相关dom
+  private clearBody() {
+    document.getElementById("screenShotContainer")?.remove();
+    document.getElementById("toolPanel")?.remove();
+    document.getElementById("optionIcoController")?.remove();
+    document.getElementById("optionPanel")?.remove();
+    document.getElementById("optionPanel")?.remove();
+    document.getElementById("textInputPanel")?.remove();
   }
 
   // 设置画笔绘制选项顶部ico样式


### PR DESCRIPTION
dom异常销毁时，会存在两个toolPanel的id，导致工具栏渲染异常。如图

<img width="773" alt="bc9e1ba617f2af152ee116de6f5cbd9" src="https://github.com/likaia/js-screen-shot/assets/32487086/4cf4e321-77ea-4daa-a573-399f21c6842e">
