### PR TITLE
feat(save-callback): 保存截图回调函数扩展截图base64信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,10 @@ sessionStorage.getItem("screenShotImg");
 * `closeCallback` 截图关闭回调函数，值为`Function`类型。
 * `triggerCallback` 截图响应回调函数，值为`Function`类型，使用html2canvas截屏时，页面图片过多时响应会较慢；使用webrtc截屏时用户点了分享，该函数为响应完成后触发的事件。回调函数返回一个对象，类型为: `{code: number,msg: string, displaySurface: string | null,displayLabel: string | null}`，code为0时代表截图加载完成，displaySurface返回的的是当前选择的窗口类型，displayLabel返回的是当前选择的标签页标识，浏览器不支持时此值为null。
 * `cancelCallback` 取消分享回到函数，值为`Function`类型，使用webrtc模式截屏时，用户点了取消或者浏览器不支持时所触发的事件。回调函数返回一个对象，类型为：`{code: number,msg: string, errorInfo: string}`，code为-1时代表用户未授权或者浏览器不支持webrtc。
-* `saveCallback` 保存截图回调函数，值为`Function`类型。回调函数中返回两个参数：
+* `saveCallback` 保存截图回调函数，值为`Function`类型。回调函数中返回三个参数：
   * `code` 状态码，number类型，为0时代表保存成功
   * `msg` 消息码，string类型。
+  * `base64` 截图的base64信息，string类型。
 * `level` 截图容器层级，值为number类型。 
 * `cutBoxBdColor` 裁剪区域边框像素点颜色，值为string类型。
 * `maxUndoNum` 最大可撤销次数, 值为number类型

--- a/src/lib/common-methods/GetCanvasImgData.ts
+++ b/src/lib/common-methods/GetCanvasImgData.ts
@@ -17,18 +17,17 @@ export function getCanvasImgData(isSave: boolean) {
     if (isSave) {
       // 将canvas转为图片
       saveCanvasToImage(screenShotCanvas, startX, startY, width, height);
-    } else {
-      // 将canvas转为base64
-      base64 = saveCanvasToBase64(
-        screenShotCanvas,
-        startX,
-        startY,
-        width,
-        height,
-        0.75,
-        plugInParameters.getWriteImgState()
-      );
     }
+    // 将canvas转为base64
+    base64 = saveCanvasToBase64(
+      screenShotCanvas,
+      startX,
+      startY,
+      width,
+      height,
+      0.75,
+      plugInParameters.getWriteImgState()
+    );
   }
   return base64;
 }

--- a/src/lib/main-entrance/PlugInParameters.ts
+++ b/src/lib/main-entrance/PlugInParameters.ts
@@ -37,7 +37,9 @@ let customImgSize = { w: 0, h: 0 };
 // 调用者定义的工具栏数据
 let userToolbar: Array<customToolbarType> = [];
 let h2cCrossImgLoadErrFn: screenShotType["h2cImgLoadErrCallback"] | null = null;
-let saveCallback: ((code: number, msg: string) => void) | null = null;
+let saveCallback:
+  | ((code: number, msg: string, base64: string) => void)
+  | null = null;
 let saveImgTitle: string | null = null;
 let canvasEvents: mouseEventType | null = null;
 
@@ -153,7 +155,9 @@ export default class PlugInParameters {
     return writeBase64;
   }
 
-  public setSaveCallback(saveFn: (code: number, msg: string) => void) {
+  public setSaveCallback(
+    saveFn: (code: number, msg: string, base64: string) => void
+  ) {
     saveCallback = saveFn;
   }
 

--- a/src/lib/split-methods/ToolClickEvent.ts
+++ b/src/lib/split-methods/ToolClickEvent.ts
@@ -147,10 +147,10 @@ export function toolClickEvent(
 
   // 保存图片
   if (toolName == "save") {
-    getCanvasImgData(true);
+    const base64 = getCanvasImgData(true);
     const callback = plugInParameters.getSaveCallback();
     if (callback) {
-      callback(0, "保存成功");
+      callback(0, "保存成功", base64);
     }
     // 销毁组件
     data.destroyDOM();

--- a/src/lib/type/ComponentType.ts
+++ b/src/lib/type/ComponentType.ts
@@ -141,7 +141,7 @@ export type screenShotType = {
     msg: string;
     errorInfo: string;
   }) => void; // webrtc截图未授权回调
-  saveCallback?: (code: number, msg: string) => void; // 保存截图回调
+  saveCallback?: (code: number, msg: string, base64: string) => void; // 保存截图回调
   position?: { top?: number; left?: number }; // 截图容器位置
   clickCutFullScreen?: boolean; // 单击截全屏启用状态, 默认值为false
   hiddenToolIco?: toolIcoType; // 需要隐藏的工具栏图标


### PR DESCRIPTION
saveCallback扩展截图的base64信息
saveCallback?: (code: number, msg: string, base64: string) => void;