### PR TITLE
feat: html2canvas模式支持传入x、y参数

### DIFF
--- a/src/lib/main-entrance/LoadCoreComponents.ts
+++ b/src/lib/main-entrance/LoadCoreComponents.ts
@@ -608,6 +608,8 @@ const h2cScreenShot = (
         ? userParamStore.screenShotDom
         : document.body,
       {
+        x: userParamStore.renderOptions.x,
+        y: userParamStore.renderOptions.y,
         onclone: userParamStore.loadCrossImg ? drawCrossImg : undefined,
         proxy: userParamStore.proxyUrl,
         ignoreElements: userParamStore.h2cIgnoreElementsFn,

--- a/src/lib/split-methods/SetPlugInParameters.ts
+++ b/src/lib/split-methods/SetPlugInParameters.ts
@@ -6,6 +6,8 @@ export function setPlugInParameters(options: screenShotType) {
   if (!options) return;
 
   const {
+    x = 0,
+    y = 0,
     enableWebRtc = true,
     screenFlow,
     canvasWidth,
@@ -64,6 +66,7 @@ export function setPlugInParameters(options: screenShotType) {
         userParamStore.setScreenShotDom(screenShotDom);
       }
     },
+
     cutBoxBdColor: () => {
       if (cutBoxBdColor) {
         userParamStore.setCutBoxBdColor(cutBoxBdColor);
@@ -119,6 +122,9 @@ export function setPlugInParameters(options: screenShotType) {
       if (canvasEvents) {
         userParamStore.setCanvasEvents(canvasEvents);
       }
+    },
+    renderOptions: ()=>{
+      userParamStore.setRenderOptions(x,y)
     }
   };
 

--- a/src/lib/type/ComponentType.ts
+++ b/src/lib/type/ComponentType.ts
@@ -119,6 +119,8 @@ export type userToolbarFnType = (canvasInfo: {
 }) => void; // 用户自定义工具栏点击事件
 
 export type screenShotType = {
+  x?:number, // 截图的x轴偏移位置
+  y?:number, // 截图的y轴偏移位置
   enableWebRtc?: boolean; // 是否启用webrtc，默认是启用状态
   screenFlow?: MediaStream; // 设备提供的屏幕流数据(用于electron环境下自己传入的视频流数据)
   level?: number; // 截图容器层级
@@ -288,6 +290,7 @@ export type UserParamStoreDataType = {
   saveCallback: ((code: number, msg: string,base64:string) => void) | null;
   saveImgTitle: string | null;
   canvasEvents: mouseEventType | null;
+  renderOptions: { x: number, y: number } // html2Canvas原生render入参
 };
 
 export type mouseEventFnType = {

--- a/src/store/UserParamStore.ts
+++ b/src/store/UserParamStore.ts
@@ -48,7 +48,8 @@ class UserParamStore {
       h2cCrossImgLoadErrFn: null,
       saveCallback: null,
       saveImgTitle: null,
-      canvasEvents: null
+      canvasEvents: null,
+      renderOptions:{ x: 0, y: 0 }
     };
   }
 
@@ -87,6 +88,7 @@ class UserParamStore {
   saveCallback = this.initialState().saveCallback;
   saveImgTitle = this.initialState().saveImgTitle;
   canvasEvents = this.initialState().canvasEvents;
+  renderOptions = this.initialState().renderOptions;
 
   constructor() {
     makeAutoObservable(this, {}, { autoBind: true });
@@ -268,6 +270,11 @@ class UserParamStore {
   // 设置画布事件监听
   setCanvasEvents(event: mouseEventType) {
     this.canvasEvents = event;
+  }
+
+  setRenderOptions(x:number,y:number){
+    this.renderOptions.x = x
+    this.renderOptions.y = y
   }
 
   // 获取画布事件监听


### PR DESCRIPTION
html2canvas模式支持传入x、y参数

测试结果：
html2canvas传入x、y参数
![微信截图_20250303111455](https://github.com/user-attachments/assets/ff3372b2-7aa9-468d-b540-5abe3065c720)

插件传入x、y参数，与html2canvas，保持了
![微信截图_20250303111746](https://github.com/user-attachments/assets/7066e04f-6b38-4c4d-bff6-84841d62ae21)
一致
