### PR TITLE
fix: 健全工具栏图标数据类型

### DIFF
--- a/src/lib/type/ComponentType.ts
+++ b/src/lib/type/ComponentType.ts
@@ -98,7 +98,7 @@ export type toolbarType = {
   title: string;
   icon?: string;
   activeIcon?: string;
-  clickFn?: () => void;
+  clickFn?: (params?: any) => void;
 };
 export type crcEventType = { state: boolean; handleFn?: () => void };
 
@@ -107,7 +107,7 @@ export type userToolbarType = {
   title: string;
   icon: string;
   activeIcon: string;
-  clickFn: () => void;
+  clickFn: userToolbarFnType;
 };
 export type customToolbarType = userToolbarType & { id: number };
 


### PR DESCRIPTION
### 问题原因

自定义图标点击事件类型提示不健全

<img width="1486" height="758" alt="image" src="https://github.com/user-attachments/assets/4f22b143-5380-483d-a4fd-d01c912593ae" />

### 改动思路

<img width="2578" height="1516" alt="image" src="https://github.com/user-attachments/assets/04b18679-57b5-428b-a09b-27391a8a9224" />

如上图，`toolbar` 在这里其实是包含**默认工具图标** 和 **自定义工具图标** 的，
所以经权衡，认为需要改动原 `toolbarType`，
这个类型的定义应该是比较 **宽泛的**、**能包含默认和自定义工具图标数据结构的**。