### PR TITLE
fix: 修复在屏幕进行缩放后，单击截取屏幕获取底部画布出现大片空白的问题

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1163,12 +1163,17 @@ export default class ScreenShot {
     ) {
       const borderSize = this.data.getBorderSize();
       this.getFullScreenStatus = true;
+      const width =
+        this.screenShotContainer.clientWidth || this.screenShotContainer.width;
+      const height =
+        this.screenShotContainer.clientHeight ||
+        this.screenShotContainer.height;
       // 设置裁剪框位置为全屏
       this.tempGraphPosition = drawCutOutBox(
         0,
         0,
-        this.screenShotContainer.width - borderSize / 2,
-        this.screenShotContainer.height - borderSize / 2,
+        width - borderSize / 2,
+        height - borderSize / 2,
         this.screenShotCanvas,
         borderSize,
         this.screenShotContainer,


### PR DESCRIPTION
## 问题描述
当浏览器页面缩放（如 125%、150%）时，点击“截取屏幕”后，底部会出现大片空白区域，导致截图不完整。

## 修复方式
修复了获取屏幕尺寸时未考虑设备像素比（devicePixelRatio）和页面缩放比例的问题，调整了 canvas 的缩放计算逻辑。

## 影响范围
- 截图插件的核心截图功能
- 特别是在高分屏或非 100% 缩放下使用时

## 测试方式
1. 将浏览器缩放设置为 125%
2. 打开 demo 页面，点击“截取屏幕”
3. 观察是否仍出现底部空白