### PR TITLE
fix: 修复工具栏、选项面板及颜色/文字大小面板在屏幕边缘溢出的问题

### DIFF
--- a/src/lib/main-entrance/InitData.ts
+++ b/src/lib/main-entrance/InitData.ts
@@ -28,8 +28,6 @@ let undoClickNum = 0;
 let history: Array<Record<string, any>> = [];
 // 文本输入工具栏点击状态
 const textClickStatus = false;
-// 工具栏超出截图容器状态
-let toolPositionStatus = false;
 // 裁剪框位置参数
 let cutOutBoxPosition: positionInfoType = {
   startX: 0,
@@ -96,7 +94,6 @@ export default class InitData {
       toolClickStatus = false;
       resetScrollbarState = false;
       textEditState = false;
-      toolPositionStatus = false;
       selectedColor = "#F53340";
       toolName = "";
       toolId = null;
@@ -306,14 +303,6 @@ export default class InitData {
     return draggingTrim;
   }
 
-  public getToolPositionStatus() {
-    return toolPositionStatus;
-  }
-
-  public setToolPositionStatus(status: boolean) {
-    toolPositionStatus = status;
-  }
-
   public setDraggingTrim(status: boolean) {
     draggingTrim = status;
   }
@@ -431,21 +420,48 @@ export default class InitData {
 
   // 设置画笔选择工具栏位置
   public setOptionPosition(position: number) {
-    // 获取截图工具栏与三角形角标容器
     optionIcoController = this.getOptionIcoController();
     optionController = this.getOptionController();
-    if (optionIcoController == null || optionController == null) return;
-    // 修改位置
+    toolController = this.getToolController();
+    if (optionIcoController == null || optionController == null || toolController == null) return;
+
     const toolPosition = this.getToolPosition();
     if (toolPosition == null) return;
+
+    const TOOLBAR_H = 44;
+    const TRIANGLE_H = 6;
+    const PANEL_H = 40;
+
+    const toolbarTop = toolPosition.top;
     const icoLeft = toolPosition.left + position + "px";
-    const icoTop = toolPosition.top + 44 + "px";
     const optionLeft = toolPosition.left + "px";
-    const optionTop = toolPosition.top + 44 + 6 + "px";
+
+    // 通过工具栏与截图选区的相对位置判断选项面板方向
+    // 工具栏在选区下方（toolbarTop >= selectionBottom）时，选项面板放工具栏下方
+    const sscTop = screenShotController ? screenShotController.offsetTop : 0;
+    const selectionBottom =
+      sscTop + cutOutBoxPosition.startY + cutOutBoxPosition.height;
+    const panelBelow = toolbarTop >= selectionBottom;
+
+    let icoTop: number;
+    let optionTop: number;
+
+    if (panelBelow) {
+      // 整体在选区下方：工具栏上，选项面板下，三角▲
+      icoTop = toolbarTop + TOOLBAR_H;
+      optionTop = toolbarTop + TOOLBAR_H + TRIANGLE_H;
+      optionIcoController.style.transform = "rotate(180deg)";
+    } else {
+      // 整体在选区上方或选区内：选项面板上，工具栏下，三角▼
+      icoTop = toolbarTop - TRIANGLE_H;
+      optionTop = toolbarTop - TRIANGLE_H - PANEL_H;
+      optionIcoController.style.transform = "rotate(0deg)";
+    }
+
     optionIcoController.style.left = icoLeft;
-    optionIcoController.style.top = icoTop;
+    optionIcoController.style.top = icoTop + "px";
     optionController.style.left = optionLeft;
-    optionController.style.top = optionTop;
+    optionController.style.top = optionTop + "px";
   }
 
   // 获取工具栏位置

--- a/src/lib/main-entrance/InitData.ts
+++ b/src/lib/main-entrance/InitData.ts
@@ -349,6 +349,16 @@ export default class InitData {
     if (optionTextSizeController == null) return;
     if (status) {
       optionTextSizeController.style.display = "flex";
+      // 根据上方剩余空间决定向上或向下弹出
+      const panelH = optionTextSizeController.offsetHeight;
+      optionController = this.getOptionController();
+      if (optionController) {
+        const spaceAbove = optionController.getBoundingClientRect().top;
+        optionTextSizeController.style.top =
+          spaceAbove >= panelH
+            ? `-${panelH}px`
+            : `${optionController.offsetHeight}px`;
+      }
       return;
     }
     optionTextSizeController.style.display = "none";
@@ -557,6 +567,16 @@ export default class InitData {
     if (colorSelectController == null) return;
     if (status) {
       colorSelectController.style.display = "flex";
+      // 根据上方剩余空间决定向上或向下弹出
+      const panelH = colorSelectController.offsetHeight;
+      optionController = this.getOptionController();
+      if (optionController) {
+        const spaceAbove = optionController.getBoundingClientRect().top;
+        colorSelectController.style.top =
+          spaceAbove >= panelH
+            ? `-${panelH}px`
+            : `${optionController.offsetHeight}px`;
+      }
       return;
     }
     colorSelectController.style.display = "none";

--- a/src/lib/split-methods/ToolClickEvent.ts
+++ b/src/lib/split-methods/ToolClickEvent.ts
@@ -60,13 +60,6 @@ function drawCutOutBoxWithoutPixel(
   ScreenShotImageController: HTMLCanvasElement
 ) {
   const data = new InitData();
-  const leftValue = data.getToolPosition()?.left || 0;
-  const topValue = data.getToolPosition()?.top || 0;
-  // 工具栏位置超出时，对其进行修正处理
-  if (topValue && data.getToolPositionStatus()) {
-    // 调整工具栏位置
-    data.setToolInfo(leftValue, topValue - 46);
-  }
   data.setToolStatus(true);
   // 获取裁剪框位置信息
   const cutBoxPosition = data.getCutOutBoxPosition();

--- a/src/main.ts
+++ b/src/main.ts
@@ -549,8 +549,6 @@ export default class ScreenShot {
     if (this.data.getToolName() == "undo") return;
     this.data.setDragging(true);
     this.drawStatus = false;
-    // 重置工具栏超出状态
-    this.data.setToolPositionStatus(false);
     const mouseX = nonNegativeData(
       event instanceof MouseEvent ? event.offsetX : event.touches[0].pageX
     );
@@ -976,21 +974,17 @@ export default class ScreenShot {
     const containerHeight =
       this.screenShotContainer.height / this.dpr -
       this.plugInParameters.getMenuBarHeight();
-    console.log(
-      containerHeight,
-      "abcdefg",
-      this.plugInParameters.getMenuBarHeight()
-    );
-    // 工具栏的位置超出截图容器时，调整工具栏位置防止超出
-    if (toolLocation.mouseY > containerHeight - 64) {
+    // 工具栏+选项面板整体高度为90px（工具栏44 + 三角6 + 选项面板40）
+    // 下方空间不足时，整体移到选区上方
+    const BLOCK_H = 90;
+    if (toolLocation.mouseY + BLOCK_H > containerHeight) {
       toolLocation.mouseY -= this.drawGraphPosition.height + 64;
-      // 超出屏幕顶部时
-      if (toolLocation.mouseY - this.plugInParameters.getMenuBarHeight() < 0) {
-        const containerHeight = parseInt(this.screenShotContainer.style.height);
-        toolLocation.mouseY = containerHeight - this.fullScreenDiffHeight;
+      // 上方空间也不足时（选项面板在工具栏上方需额外46px），兜底到容器底部附近
+      const menuBarH = this.plugInParameters.getMenuBarHeight();
+      if (toolLocation.mouseY - menuBarH < 46) {
+        const ch = parseInt(this.screenShotContainer.style.height);
+        toolLocation.mouseY = ch - this.fullScreenDiffHeight;
       }
-      // 设置工具栏超出状态为true
-      this.data.setToolPositionStatus(true);
       // 隐藏裁剪框尺寸显示容器
       this.data.setCutBoxSizeStatus(false);
     }


### PR DESCRIPTION
Closes #183

## 问题

选中较大区域后，工具栏被挪到截图选区上方时，如果此时点击画笔等工具：
1. 工具栏会因 `-46px` 的二次移动飞出屏幕外
<img width="1064" height="1013" alt="image" src="https://github.com/user-attachments/assets/66eb5b24-ee45-4dc9-b07e-700b2729590e" />

2. 选项面板（画笔大小/颜色选择/文字大小）的弹出位置固定写死，不感知屏幕剩余空间，也会溢出
<img width="909" height="1010" alt="image" src="https://github.com/user-attachments/assets/e245d9f1-0cd4-4f43-a79f-b669a14475f8" />


## 修改内容

**commit 1：工具栏与选项面板三段式定位**

将工具栏与选项面板视为一个整体（总高 90px），在框选结束时一次性确定位置，之后显隐不再引起位移：

- 截图选区**下方**有空间 → 整体放下方，选项面板在工具栏下方（三角 ▲）
- 截图选区**上方**有空间 → 整体放上方，选项面板在工具栏上方（三角 ▼）
- 上下均无空间 → 整体嵌入截图选区内靠底边

同时删除首次点击工具时对工具栏进行 `-46px` 二次移动的逻辑（`toolPositionStatus`），消除工具栏跳动问题。

**commit 2：颜色面板与文字大小面板弹出方向动态判断**

原先通过 CSS 硬编码 `top: -225px` / `top: -321px` 固定向上弹出。改为弹出时动态判断上方剩余空间：空间充足则向上弹，否则向下弹。

## Test plan

- [x] 普通选区（屏幕中间）→ 点击工具，选项面板在工具栏下方，工具栏不跳动
- [x] 选区靠近底部（工具栏移到选区上方）→ 点击工具，选项面板在工具栏上方，三角方向正确
- [x] 上述场景下点击颜色色块 / 文字大小，弹窗不溢出屏幕
- [x] 全屏截图场景正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)